### PR TITLE
[Fix] #111 - QA 최종 수정사항 반영

### DIFF
--- a/Napzak-iOS/Napzak-iOS.xcodeproj/project.pbxproj
+++ b/Napzak-iOS/Napzak-iOS.xcodeproj/project.pbxproj
@@ -110,6 +110,7 @@
 		D045DEFA2D8383CC00EB1EB6 /* TextEditor+.swift in Sources */ = {isa = PBXBuildFile; fileRef = D045DEF42D8383CC00EB1EB6 /* TextEditor+.swift */; };
 		D045DEFC2D8383CC00EB1EB6 /* TextField+.swift in Sources */ = {isa = PBXBuildFile; fileRef = D045DEF32D8383CC00EB1EB6 /* TextField+.swift */; };
 		D05A03922D91B67200659C74 /* View+.swift in Sources */ = {isa = PBXBuildFile; fileRef = D05A03912D91B67200659C74 /* View+.swift */; };
+		D06B835B2DDB15D1008A0D14 /* ProductEventManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = D06B835A2DDB15C6008A0D14 /* ProductEventManager.swift */; };
 		D06E5B362DAE0A88002E68A1 /* SearchView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D06E5B352DAE0A83002E68A1 /* SearchView.swift */; };
 		D06E5B382DAE2121002E68A1 /* NZSegmentedControl.swift in Sources */ = {isa = PBXBuildFile; fileRef = D06E5B372DAE2111002E68A1 /* NZSegmentedControl.swift */; };
 		D06F13962DA300CB0029698C /* NavigationRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = D06F13952DA300C30029698C /* NavigationRouter.swift */; };
@@ -311,6 +312,7 @@
 		D045DEF62D8383CC00EB1EB6 /* String+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+.swift"; sourceTree = "<group>"; };
 		D045DEF72D8383CC00EB1EB6 /* Encodable+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Encodable+.swift"; sourceTree = "<group>"; };
 		D05A03912D91B67200659C74 /* View+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+.swift"; sourceTree = "<group>"; };
+		D06B835A2DDB15C6008A0D14 /* ProductEventManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductEventManager.swift; sourceTree = "<group>"; };
 		D06E5B352DAE0A83002E68A1 /* SearchView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchView.swift; sourceTree = "<group>"; };
 		D06E5B372DAE2111002E68A1 /* NZSegmentedControl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NZSegmentedControl.swift; sourceTree = "<group>"; };
 		D06F13952DA300C30029698C /* NavigationRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationRouter.swift; sourceTree = "<group>"; };
@@ -819,6 +821,7 @@
 			children = (
 				D64560F32DC33A29003D2E2B /* Auth */,
 				D64561242DC48013003D2E2B /* Onboarding */,
+				D06B835A2DDB15C6008A0D14 /* ProductEventManager.swift */,
 				D67F8DB92DD5C11700C0847F /* ProductLikeManager.swift */,
 			);
 			path = Core;
@@ -1693,6 +1696,7 @@
 				D0F035A32DC0A0DC003D0CBF /* GenreDetailView.swift in Sources */,
 				D0310AEE2DCA592E00C265EC /* ProductCondition.swift in Sources */,
 				D0F0356F2DBF441E003D0CBF /* PreferGenreResponseDTO.swift in Sources */,
+				D06B835B2DDB15D1008A0D14 /* ProductEventManager.swift in Sources */,
 				6CD972CD2DC7BCB7000AE85E /* SellRegisterRequestDTO.swift in Sources */,
 				D0F035702DBF441E003D0CBF /* GenreNameResponseDTO.swift in Sources */,
 			);

--- a/Napzak-iOS/Napzak-iOS/Global/Core/ProductEventManager.swift
+++ b/Napzak-iOS/Napzak-iOS/Global/Core/ProductEventManager.swift
@@ -1,0 +1,16 @@
+//
+//  ProductEventManager.swift
+//  Napzak-iOS
+//
+//  Created by 조혜린 on 5/19/25.
+//
+
+import Combine
+
+final class ProductEventManager {
+    static let shared = ProductEventManager()
+    
+    private init() {}
+
+    let productChanged = PassthroughSubject<Void, Never>()
+}

--- a/Napzak-iOS/Napzak-iOS/Presentation/Home/View/HomeView.swift
+++ b/Napzak-iOS/Napzak-iOS/Presentation/Home/View/HomeView.swift
@@ -91,11 +91,11 @@ struct HomeView: View {
                 viewModel.externalURLToOpen = nil
             }
         }
-        .onAppear {
-            //탭 간 전환시 데이터를 새로 불러오기 위한 코드
-            //추후 상품에 관한 전역 구현체가 구현되면 제거해도 무방
-            viewModel.fetchHomeData()
-            scrollToTopTrigger.toggle()
+        .onChange(of: tabRouter.selectedTab) { tab in
+            if tab != .search {
+                viewModel.fetchHomeData()
+                scrollToTopTrigger.toggle()
+            }
         }
     }
 }

--- a/Napzak-iOS/Napzak-iOS/Presentation/Market/MarketView.swift
+++ b/Napzak-iOS/Napzak-iOS/Presentation/Market/MarketView.swift
@@ -11,6 +11,8 @@ import Kingfisher
 
 struct MarketView: View {
     
+    //MARK: - Property Wrappers
+    
     @EnvironmentObject private var navigationRouter: NavigationRouter
 
     @StateObject var viewModel: MarketViewModel
@@ -21,8 +23,18 @@ struct MarketView: View {
     @State private var isReportModalPresented = false
     @State private var scrollToTopTrigger: Bool = false
     
+    //MARK: - Properties
+
     private let productCellWidth = (UIScreen.main.bounds.width - 76) / 2
     private let columns = [GridItem(.flexible(), spacing: 20), GridItem(.flexible())]
+    
+    //MARK: - Init
+    
+    init(storeId: Int) {
+        _viewModel = StateObject(wrappedValue: MarketViewModel(storeId: storeId))
+    }
+    
+    //MARK: - Body
     
     var body: some View {
         ZStack(alignment: .bottom) {
@@ -121,12 +133,6 @@ struct MarketView: View {
             Task {
                 await viewModel.fetchProducts()
                 scrollToTopTrigger.toggle()
-            }
-        }
-        .onAppear {
-            Task {
-                await viewModel.fetchStoreDetail()
-                await viewModel.fetchProducts()
             }
         }
     }
@@ -435,13 +441,5 @@ struct MarketView: View {
             Spacer()
         }
         .frame(maxWidth: .infinity)
-    }
-}
-
-// MARK: - Preview
-struct MarketView_Previews: PreviewProvider {
-    static var previews: some View {
-        MarketView(viewModel: MarketViewModel(storeId: 0))
-            .environmentObject(NavigationRouter())
     }
 }

--- a/Napzak-iOS/Napzak-iOS/Presentation/Market/MarketViewModel.swift
+++ b/Napzak-iOS/Napzak-iOS/Presentation/Market/MarketViewModel.swift
@@ -49,6 +49,7 @@ final class MarketViewModel: ObservableObject {
         
         setupLikeObserver()
         setupLikePublisher()
+        setupProductEventObserver()
         
         Task {
             await fetchStoreDetail()
@@ -197,5 +198,17 @@ extension MarketViewModel {
                 }
             }
         }
+    }
+    
+    private func setupProductEventObserver() {
+        ProductEventManager.shared.productChanged
+            .sink { [weak self] in
+                guard let self = self else { return }
+                
+                Task {
+                    await self.fetchProducts()
+                }
+            }
+            .store(in: &cancellables)
     }
 }

--- a/Napzak-iOS/Napzak-iOS/Presentation/ProductDetail/ViewModel/ProductDetailViewModel.swift
+++ b/Napzak-iOS/Napzak-iOS/Presentation/ProductDetail/ViewModel/ProductDetailViewModel.swift
@@ -156,6 +156,7 @@ extension ProductDetailViewModel {
             showStatusToast = true
             try? await Task.sleep(for: .seconds(1.5))
             showStatusToast = false
+            ProductEventManager.shared.productChanged.send(())
         case .failure(let error):
             logger.error("getSellProduct failed: \(error.localizedDescription)")
         }
@@ -167,6 +168,7 @@ extension ProductDetailViewModel {
         
         switch result {
         case .success:
+            ProductEventManager.shared.productChanged.send(())
             showStatusToast = true
             try? await Task.sleep(for: .seconds(1.5))
             showStatusToast = false

--- a/Napzak-iOS/Napzak-iOS/Presentation/Register/ViewModel/RegisterViewModel.swift
+++ b/Napzak-iOS/Napzak-iOS/Presentation/Register/ViewModel/RegisterViewModel.swift
@@ -331,6 +331,7 @@ extension RegisterViewModel {
             switch result {
             case .success(let response):
                 logger.info("✅ 상품 수정 성공: \(response.data!.productId)")
+                ProductEventManager.shared.productChanged.send(())
                 self.productId = response.data?.productId
             case .failure(let error):
                 logger.error("❌ 상품 수정 실패: \(error.localizedDescription)")
@@ -390,6 +391,7 @@ extension RegisterViewModel {
             switch result {
             case .success(let response):
                 logger.info("✅ 상품 수정 성공: \(response.data!.productId)")
+                ProductEventManager.shared.productChanged.send(())
                 self.productId = response.data?.productId
             case .failure(let error):
                 logger.error("❌ 상품 수정 실패: \(error.localizedDescription)")

--- a/Napzak-iOS/Napzak-iOS/Presentation/Search/View/GenreDetailView.swift
+++ b/Napzak-iOS/Napzak-iOS/Presentation/Search/View/GenreDetailView.swift
@@ -15,7 +15,7 @@ struct GenreDetailView: View {
 
     @EnvironmentObject private var navigationRouter: NavigationRouter
 
-    @ObservedObject var viewModel: GenreDetailViewModel
+    @StateObject private var viewModel: GenreDetailViewModel
     
     @State private var isSortModalPresented = false
     @State private var scrollToTopTrigger: Bool = false
@@ -25,6 +25,15 @@ struct GenreDetailView: View {
     private let screenWidth = UIScreen.main.bounds.width
     private let columns = [GridItem(.flexible(), spacing: 20), GridItem(.flexible())]
     private let productCellWidth = (UIScreen.main.bounds.width - 76) / 2
+    
+    //MARK: - Init
+    
+    init(genreId: Int, genreName: String) {
+        _viewModel = StateObject(wrappedValue: GenreDetailViewModel(
+            genreId: genreId,
+            genreName: genreName
+        ))
+    }
 
     //MARK: - Body
     
@@ -308,18 +317,4 @@ private extension GenreDetailView {
             print("\(product.wrappedValue.id)번 상품")
         }
     }
-}
-
-#Preview {
-    struct PreviewContainer: View {
-        @State private var isSortModalPresented = false
-        
-        var body: some View {
-            GenreDetailView(
-                viewModel: GenreDetailViewModel(genreId: 1, genreName: "사카모토 데이즈")
-            )
-        }
-    }
-    
-    return PreviewContainer()
 }

--- a/Napzak-iOS/Napzak-iOS/Presentation/Search/View/SearchView.swift
+++ b/Napzak-iOS/Napzak-iOS/Presentation/Search/View/SearchView.swift
@@ -127,7 +127,7 @@ extension SearchView {
     
     private var searchHeader: some View {
         VStack(spacing: 0){
-            HStack {
+            HStack(alignment: .center, spacing: 0) {
                 if !viewModel.searchWord.isEmpty {
                     Button {
                         navigationRouter.pop()
@@ -135,7 +135,7 @@ extension SearchView {
                         Image(.iconBack)
                             .frame(width: 34)
                     }
-                    .padding(.leading, 27)
+                    .padding(.leading, 16)
                     .padding(.bottom, 19)
                 }
 

--- a/Napzak-iOS/Napzak-iOS/Presentation/TabBar/View/NZTabBarView.swift
+++ b/Napzak-iOS/Napzak-iOS/Presentation/TabBar/View/NZTabBarView.swift
@@ -88,7 +88,7 @@ struct NZTabBarView: View {
                     SearchInputView()
                     
                 case .marketView(let storeId):
-                    MarketView(viewModel: MarketViewModel(storeId: storeId))
+                    MarketView(storeId: storeId)
                     
                 case .ProfileEditView:
                     ProfileEditView()

--- a/Napzak-iOS/Napzak-iOS/Presentation/TabBar/View/NZTabBarView.swift
+++ b/Napzak-iOS/Napzak-iOS/Presentation/TabBar/View/NZTabBarView.swift
@@ -94,12 +94,8 @@ struct NZTabBarView: View {
                     ProfileEditView()
 
                 case .genreDetailView(genreId: let genreId, genreName: let genreName):
-                    GenreDetailView(
-                        viewModel: GenreDetailViewModel(
-                            genreId: genreId,
-                            genreName: genreName
-                        )
-                    )
+                    GenreDetailView(genreId: genreId, genreName: genreName)
+                    
                 case .productDetailView(productId: let productId):
                     ProductDetailView(viewModel: ProductDetailViewModel(productId: productId))
 


### PR DESCRIPTION
## 🌴 작업한 브랜치
- #111


## ✅ 작업한 내용
<!-- 작업한 내용 적어주세요! -->
- [x] **홈 화면에서 상세페이지 들어갔다오면 스크롤 위치 초기화되는 현상 해결**
- [x] **마켓 내부에서 제일 아래 상품 들어갔다 나오면 나타나는 스크롤 오류 해결**

  이 문제는 화면이 나타날 때마다 뷰모델이 초기화 되어, 상품 목록 데이터 전체가 다시 생성되면서 뷰를 렌더링 하는 과정에서 발생한 오류임을 확인했습니다!

  일반 VStack의 경우에는 UI 전체를 처음부터 렌더링하고 유지하기 때문에 문제가 되지 않을 수 있지만, 스티키헤더 구현을 위해 LazyVStack을 사용함에 따라 해당 오류가 더 크게 나타난 것으로 생각됩니다.. (같은 방식으로 구현한 장르 페이지도 같은 문제가 나타나씁니다..)

  따라서 뷰모델 초기화 방식 자체를 변경하고, 상품 데이터의 변경을 감지할 수 있는 `ProductEventManager`를 추가하여 상품 목록의 변경이 일어났을 때에만 서버통신하여 데이터를 변경할 수 있도록 수정하였습니다~!
  
- [x] **검색화면 네비게이션 바 leading 패딩 조절**


<!--
```
넣고싶은 코드가 있다면 적어주세요
```
-->


## ❗️PR Point
<!-- 부족했던 점 혹은 개선하고 싶은 방향이 있다면 얘기해주세요 -->

<!--
```
넣고싶은 코드가 있다면 적어주세요
```
-->


## 📸 스크린샷
<!-- 스크린 샷을 첨부해주세요 -->
|기능|스크린샷|
|:--:|:--:|
|GIF|<img src = "" width ="250">|


## 📟 관련 이슈
- Resolved: #111
