### PR TITLE
[Chore] #121 - 배너 넘어가는 시간 개선

### DIFF
--- a/Napzak-iOS/Napzak-iOS/Presentation/Home/View/Components/CarouselView.swift
+++ b/Napzak-iOS/Napzak-iOS/Presentation/Home/View/Components/CarouselView.swift
@@ -64,7 +64,7 @@ struct CarouselView: View {
         }
         .onReceive(timer) { _ in
             guard !timerPaused && !banners.isEmpty && !isDragging else { return }
-            withAnimation(.easeInOut(duration: 0.3)) {
+            withAnimation(.easeInOut(duration: 1.0)) {
                 if currentPage == displayBanners.count - 1 {
                     currentPage = 1
                 } else {


### PR DESCRIPTION
## 🌴 작업한 브랜치
- #121 


## ✅ 작업한 내용
<!-- 작업한 내용 적어주세요! -->
자동 스크롤일 때, 배너 이동되는 시간이 0.3초에서 1초로 바꿨습니다.

<!--
```
넣고싶은 코드가 있다면 적어주세요
```
-->


## ❗️PR Point
<!-- 부족했던 점 혹은 개선하고 싶은 방향이 있다면 얘기해주세요 -->

<!--
```
넣고싶은 코드가 있다면 적어주세요
```
-->


## 📸 스크린샷
<!-- 스크린 샷을 첨부해주세요 -->
|기능|스크린샷|
|:--:|:--:|
|GIF|<img src = "" width ="250">|


## 📟 관련 이슈
- Resolved: #121 
