### PR TITLE
[Fix] #182 - 장르 페이지에서 navigation reset 시 홈 탭으로 이동

### DIFF
--- a/Napzak-iOS/Napzak-iOS/Presentation/Search/View/GenreDetailView.swift
+++ b/Napzak-iOS/Napzak-iOS/Presentation/Search/View/GenreDetailView.swift
@@ -14,6 +14,7 @@ struct GenreDetailView: View {
     //MARK: - Property Wrappers
 
     @EnvironmentObject private var navigationRouter: NavigationRouter
+    @EnvironmentObject private var tabRouter: TabRouter
 
     @StateObject private var viewModel: GenreDetailViewModel
     
@@ -104,6 +105,7 @@ private extension GenreDetailView {
             }
             
             Button {
+                tabRouter.switchToHome()
                 navigationRouter.reset()
             } label: {
                 Image(.iconHome)


### PR DESCRIPTION
## 🌴 작업한 브랜치
- #182


## ✅ 작업한 내용
<!-- 작업한 내용 적어주세요! -->

<!--
```
넣고싶은 코드가 있다면 적어주세요
```
-->


## ❗️PR Point
<!-- 부족했던 점 혹은 개선하고 싶은 방향이 있다면 얘기해주세요 -->

<!--
```
넣고싶은 코드가 있다면 적어주세요
```
-->


## 📸 스크린샷
<!-- 스크린 샷을 첨부해주세요 -->
|기능|스크린샷|
|:--:|:--:|
|GIF|<img src = "" width ="250">|


## 📟 관련 이슈
- Resolved: #182
