### PR TITLE
[Fix] #191 - CS 사항에 따른 텍스트 수정

### DIFF
--- a/Napzak-iOS/Napzak-iOS/Global/Components/AppAlertView.swift
+++ b/Napzak-iOS/Napzak-iOS/Global/Components/AppAlertView.swift
@@ -29,7 +29,14 @@ struct AppAlertView: View {
         var message: String {
             switch self {
             case .update: return "원활한 서비스 이용을 위해\n최신 버전으로 업데이트해주세요."
-            case .banned: return "서비스 운영 정책에 따라\n현재 계정은 이용이 제한된 상태입니다.\n관련 문의: napzakmarket@gmail.com"
+            case .banned: return "서비스 운영 정책에 따라\n현재 계정은 이용이 제한된 상태입니다."
+            }
+        }
+        
+        var napzakEmail: String? {
+            switch self {
+            case .update: return nil
+            case .banned: return "napzakmarket@gmail.com"
             }
         }
         
@@ -60,11 +67,25 @@ struct AppAlertView: View {
                 .applyNapzakFont(.body1Bold16)
                 .padding(.top, 12)
             
-            Text(style.message)
-                .multilineTextAlignment(.center)
-                .applyNapzakFont(.caption1SemiBold12, lineSpacingEnabled: false)
-                .foregroundStyle(Color.napzakGrayScale(.gray200))
-                .padding(.top, 10)
+            Group {
+                Text(style.message)
+                    .padding(.top, 10)
+                
+                if let email = style.napzakEmail {
+                    HStack(alignment: .center, spacing: 0) {
+                        Text("관련 문의: ")
+                        
+                        Text(email)
+                            .underline()
+                            .onTapGesture {
+                                UIPasteboard.general.string = email
+                            }
+                    }
+                }
+            }
+            .multilineTextAlignment(.center)
+            .applyNapzakFont(.caption1SemiBold12, lineSpacingEnabled: false)
+            .foregroundStyle(Color.napzakGrayScale(.gray200))
             
             Button {
                 onConfirm()

--- a/Napzak-iOS/Napzak-iOS/Global/Components/AppAlertView.swift
+++ b/Napzak-iOS/Napzak-iOS/Global/Components/AppAlertView.swift
@@ -29,7 +29,7 @@ struct AppAlertView: View {
         var message: String {
             switch self {
             case .update: return "원활한 서비스 이용을 위해\n최신 버전으로 업데이트해주세요."
-            case .banned: return "해당 계정은 정책 위반으로 인해\n앱 서비스 접근이 불가합니다."
+            case .banned: return "서비스 운영 정책에 따라\n현재 계정은 이용이 제한된 상태입니다.\n관련 문의: napzakmarket@gmail.com"
             }
         }
         
@@ -61,7 +61,6 @@ struct AppAlertView: View {
                 .padding(.top, 12)
             
             Text(style.message)
-                .lineLimit(2)
                 .multilineTextAlignment(.center)
                 .applyNapzakFont(.caption1SemiBold12, lineSpacingEnabled: false)
                 .foregroundStyle(Color.napzakGrayScale(.gray200))

--- a/Napzak-iOS/Napzak-iOS/Presentation/Home/ViewModel/HomeViewModel.swift
+++ b/Napzak-iOS/Napzak-iOS/Presentation/Home/ViewModel/HomeViewModel.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 import os
-import SwiftUICore
+import SwiftUI
 import Combine
 
 @MainActor

--- a/Napzak-iOS/Napzak-iOS/Presentation/Report/View/ReportView.swift
+++ b/Napzak-iOS/Napzak-iOS/Presentation/Report/View/ReportView.swift
@@ -217,18 +217,18 @@ extension ReportView {
             .frame(height: 13)
         }
         .padding(.horizontal, 28)
-        .padding(.bottom, 8)
+        .padding(.bottom, 9)
     }
     
     private var contactAddressSection: some View {
         VStack(alignment: .leading, spacing: 0) {
-            Text("연락처 입력")
+            Text("이메일 주소 입력")
                 .applyNapzakFont(.body5SemiBold14)
                 .foregroundStyle(Color.napzakGrayScale(.gray500))
                 .frame(height: 18)
                 .padding(.bottom, 16)
             
-            TextField("신고 검토결과를 받아볼 이메일 또는 전화번호를 알려주세요", text: $viewModel.reportModel.contactAddress)
+            TextField("신고 관련 안내 및 확인을 위해 이메일 주소를 입력해 주세요.", text: $viewModel.reportModel.contactAddress)
                 .applyNapzakFont(.caption2Medium12)
                 .foregroundStyle(Color.napzakGrayScale(.gray500))
                 .padding(.horizontal, 16)
@@ -273,7 +273,7 @@ extension ReportView {
     private var toastView: some View {
         VStack {
             Spacer()
-            Text("소중한 신고 감사합니다! 🙏\n\n신고 내용을 꼼꼼히 검토하여 \n입력하신 연락처로 결과를 안내해드릴게요.\n추가 정보가 필요할 경우 동일한 연락처로 문의드릴 수 있어요.")
+            Text("소중한 신고 감사합니다! 🙏\n\n신고 내용을 꼼꼼히 검토하여 \n입력하신 이메일로 결과를 안내해드릴게요.\n추가 정보가 필요할 경우 동일한 이메일로 문의드릴 수 있어요.")
                 .applyNapzakFont(.caption1SemiBold12)
                 .foregroundColor(Color.napzakGrayScale(.white))
                 .multilineTextAlignment(.center)


### PR DESCRIPTION
## 🌴 작업한 브랜치
- `fix#191`


## ✅ 작업한 내용
<!-- 작업한 내용 적어주세요! -->
첫 CS를 처리하는 과정에서 디자인(텍스트) 수정의 필요성을 확인

1. [신고하기] 연락처 입력 필드 텍스트 수정

현재 신고하기 화면에서 연락 수단으로 전화번호 입력이 가능한 상태.
그러나 납작마켓은 공식 전화번호가 존재하지 않으며, 실제 CS 대응 시 전화 및 문자 연락을 진행하지 않고 있음.
이로 인해, 신고자가 전화번호를 입력할 경우 CS 과정에서 기획 측 개인 전화번호 노출 위험이 발생하거나
현실적으로 대응이 불가능한 연락 수단이 수집되는 문제를 발견.
따라서 신고 후 소통 수단을 이메일로 통일하고자 함.

📌 AS-IS: 신고 검토 결과를 받아볼 이메일 또는 전화번호를 알려주세요
🛠️ TO-BE: 신고 관련 안내 및 확인을 위해 이메일 주소를 입력해 주세요.

2. [제한 유저] 앱 접근 불가 모달 텍스트 수정

현재 제한 유저 관련 처리 상황은 다음과 같다.

앱 로그인 자체가 불가.
푸시 알림, 인앱 알림 등 추가 안내 수단이 없음.
이로 인해 유저는 자신의 계정이 제한된 상태임은 인지하더라도, 이에 대해 확인하거나 추가 문의를 진행할 수 있는 공식적인 경로를 확인하기 어려움.
따라서 유저에게 구체적인 제한 사유는 노출하지 않더라도, 문의 가능한 공식 소통 창구에 대한 안내는 필요한 상황.

📌 AS-IS: 정책 위반으로 인해 앱 서비스 접근이 불가합니다.
🛠️ TO-BE:
서비스 운영 정책에 따라 현재 계정은 이용이 제한된 상태입니다.
관련 문의: [napzakmarket@gmail.com](mailto:napzakmarket@gmail.com)


## 📸 스크린샷
<!-- 스크린 샷을 첨부해주세요 -->
|기능|신고 시 연락처 입력 필드 및 토스트 알림|제한된 유저 안내 메세지|
|:--:|:--:|:--:|
|GIF|<img src = "https://github.com/user-attachments/assets/4e82af53-95c4-4c4f-97ce-c0801fb28057" width ="250">|<img src = "https://github.com/user-attachments/assets/baf287b7-8ba9-42d9-a09b-36abc425cbad" width ="250">|



## 📟 관련 이슈
- Resolved: #191
