### PR TITLE
[Fix] #203 - 3차 번호인증 QA

### DIFF
--- a/Napzak-iOS/Napzak-iOS.xcodeproj/project.pbxproj
+++ b/Napzak-iOS/Napzak-iOS.xcodeproj/project.pbxproj
@@ -2658,7 +2658,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.0.2;
+				MARKETING_VERSION = 2.1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.napzakmarket.napzak;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -2699,7 +2699,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.0.2;
+				MARKETING_VERSION = 2.1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.napzakmarket.napzak;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/Napzak-iOS/Napzak-iOS/Application/RootView.swift
+++ b/Napzak-iOS/Napzak-iOS/Application/RootView.swift
@@ -45,21 +45,13 @@ struct RootView: View {
             }
 
             if authManager.isAuthenticated {
-                Task {
-                    await phoneVerificationManager.refreshStatus()
-                }
+                handleAuthenticatedSessionStart()
             } else {
                 phoneVerificationManager.reset()
             }
         }
         .onChange(of: authManager.isAuthenticated) { isAuthenticated in
-            if isAuthenticated {
-                Task {
-                    await authManager.fetchMyStoreId()
-                    await authManager.fetchChatRoomIdsToWebSocket()
-                    await phoneVerificationManager.refreshStatus()
-                }
-            } else {
+            if isAuthenticated == false {
                 phoneVerificationManager.reset()
             }
         }
@@ -74,6 +66,16 @@ struct RootView: View {
 }
 
 extension RootView {
+    private func handleAuthenticatedSessionStart() {
+        phoneVerificationManager.reset()
+
+        Task {
+            await authManager.fetchMyStoreId()
+            await authManager.fetchChatRoomIdsToWebSocket()
+            await phoneVerificationManager.refreshStatus()
+        }
+    }
+
     private func openAppStore() {
         if let url = URL(string: "itms-apps://itunes.apple.com/app/id\(appID)") {
             UIApplication.shared.open(url)

--- a/Napzak-iOS/Napzak-iOS/Application/RootView.swift
+++ b/Napzak-iOS/Napzak-iOS/Application/RootView.swift
@@ -16,7 +16,6 @@ struct RootView: View {
     @State private var isShowingSplash = true
     
     let appID = "6740986515"
-    
     var body: some View {
         Group {
             if isShowingSplash {

--- a/Napzak-iOS/Napzak-iOS/Features/PhoneVerification/Data/Repositories/DefaultPhoneVerificationRepository.swift
+++ b/Napzak-iOS/Napzak-iOS/Features/PhoneVerification/Data/Repositories/DefaultPhoneVerificationRepository.swift
@@ -72,7 +72,7 @@ struct DefaultPhoneVerificationRepository: PhoneVerificationRepository {
 
             return .success(
                 PhoneVerificationCodeVerificationResult(
-                    isPhoneVerified: data.isPhoneVerified,
+                    isCodeMatched: data.isCodeMatched,
                     remainingRequestCount: data.remainingRequestCount
                 )
             )

--- a/Napzak-iOS/Napzak-iOS/Features/PhoneVerification/Domain/Entities/PhoneVerificationCodeVerificationResult.swift
+++ b/Napzak-iOS/Napzak-iOS/Features/PhoneVerification/Domain/Entities/PhoneVerificationCodeVerificationResult.swift
@@ -8,6 +8,6 @@
 import Foundation
 
 struct PhoneVerificationCodeVerificationResult: Equatable {
-    let isPhoneVerified: Bool
+    let isCodeMatched: Bool
     let remainingRequestCount: Int
 }

--- a/Napzak-iOS/Napzak-iOS/Features/PhoneVerification/Domain/Entities/PhoneVerificationSession.swift
+++ b/Napzak-iOS/Napzak-iOS/Features/PhoneVerification/Domain/Entities/PhoneVerificationSession.swift
@@ -12,7 +12,7 @@ struct PhoneVerificationSession: Equatable {
     let phoneNumber: String
     let verificationCode: String
     let isCodeSent: Bool
-    let isVerified: Bool
+    let isCodeVerified: Bool
     let isAgeConfirmed: Bool
 
     static let empty = PhoneVerificationSession(
@@ -20,7 +20,7 @@ struct PhoneVerificationSession: Equatable {
         phoneNumber: "",
         verificationCode: "",
         isCodeSent: false,
-        isVerified: false,
+        isCodeVerified: false,
         isAgeConfirmed: false
     )
 
@@ -29,7 +29,7 @@ struct PhoneVerificationSession: Equatable {
         phoneNumber: String? = nil,
         verificationCode: String? = nil,
         isCodeSent: Bool? = nil,
-        isVerified: Bool? = nil,
+        isCodeVerified: Bool? = nil,
         isAgeConfirmed: Bool? = nil
     ) -> PhoneVerificationSession {
         PhoneVerificationSession(
@@ -37,7 +37,7 @@ struct PhoneVerificationSession: Equatable {
             phoneNumber: phoneNumber ?? self.phoneNumber,
             verificationCode: verificationCode ?? self.verificationCode,
             isCodeSent: isCodeSent ?? self.isCodeSent,
-            isVerified: isVerified ?? self.isVerified,
+            isCodeVerified: isCodeVerified ?? self.isCodeVerified,
             isAgeConfirmed: isAgeConfirmed ?? self.isAgeConfirmed
         )
     }

--- a/Napzak-iOS/Napzak-iOS/Features/PhoneVerification/Presentation/Components/VerificationSectionView.swift
+++ b/Napzak-iOS/Napzak-iOS/Features/PhoneVerification/Presentation/Components/VerificationSectionView.swift
@@ -11,7 +11,7 @@ struct VerificationSectionView: View {
     @Binding var code: String
 
     let timerText: String
-    let isVerified: Bool
+    let isCodeVerified: Bool
     let isCodeInputEnabled: Bool
     let buttonState: VerifyButtonState
 
@@ -40,7 +40,7 @@ extension VerificationSectionView {
                 .frame(width: 1, height: 30)
 
             HStack(spacing: 6) {
-                if isVerified {
+                if isCodeVerified {
                     Image(systemName: "checkmark.circle")
                         .font(.system(size: 12))
                         .foregroundStyle(Color.green)
@@ -101,7 +101,7 @@ extension VerificationSectionView {
     }
 
     private var timerTextColor: Color {
-        isVerified
+        isCodeVerified
         ? Color.napzakGrayScale(.gray300)
         : Color.napzakPrimary(.purple500)
     }
@@ -147,7 +147,7 @@ extension VerificationSectionView {
     VerificationSectionView(
         code: .constant(""),
         timerText: "02:59",
-        isVerified: false,
+        isCodeVerified: false,
         isCodeInputEnabled: true,
         buttonState: .disabled,
         onTapVerify: {}
@@ -159,7 +159,7 @@ extension VerificationSectionView {
     VerificationSectionView(
         code: .constant("123456"),
         timerText: "00:21",
-        isVerified: false,
+        isCodeVerified: false,
         isCodeInputEnabled: true,
         buttonState: .enabled,
         onTapVerify: {}
@@ -171,7 +171,7 @@ extension VerificationSectionView {
     VerificationSectionView(
         code: .constant("123456"),
         timerText: "00:00",
-        isVerified: true,
+        isCodeVerified: true,
         isCodeInputEnabled: false,
         buttonState: .completed,
         onTapVerify: {}

--- a/Napzak-iOS/Napzak-iOS/Features/PhoneVerification/Presentation/Model/PhoneVerificationViewState.swift
+++ b/Napzak-iOS/Napzak-iOS/Features/PhoneVerification/Presentation/Model/PhoneVerificationViewState.swift
@@ -30,7 +30,7 @@ struct PhoneVerificationViewState: Equatable {
 
     var isResendAvailable: Bool {
         session.isCodeSent
-        && session.isVerified == false
+        && session.isCodeVerified == false
         && remainingSeconds == 0
         && (remainingRequestCount ?? 0) > 0
     }
@@ -42,12 +42,12 @@ struct PhoneVerificationViewState: Equatable {
 
     var isVerificationCodeInputEnabled: Bool {
         session.isCodeSent
-        && session.isVerified == false
+        && session.isCodeVerified == false
         && remainingSeconds > 0
     }
 
     var verifyButtonState: VerifyButtonState {
-        if session.isVerified {
+        if session.isCodeVerified {
             return .completed
         }
 
@@ -59,6 +59,6 @@ struct PhoneVerificationViewState: Equatable {
     }
 
     var isNextEnabled: Bool {
-        session.isVerified && session.isAgeConfirmed
+        session.isCodeVerified && session.isAgeConfirmed
     }
 }

--- a/Napzak-iOS/Napzak-iOS/Features/PhoneVerification/Presentation/View/PhoneVerificationView.swift
+++ b/Napzak-iOS/Napzak-iOS/Features/PhoneVerification/Presentation/View/PhoneVerificationView.swift
@@ -12,15 +12,18 @@ struct PhoneVerificationView: View {
     @EnvironmentObject private var phoneVerificationManager: PhoneVerificationManager
     
     private let navigationStyle: VerificationNavigationStyle
+    private let shouldRegisterOnNext: Bool
     private let onBack: () -> Void
     private let onNext: () -> Void
     
     init(
         navigationStyle: VerificationNavigationStyle = .basic,
+        shouldRegisterOnNext: Bool = false,
         onBack: @escaping () -> Void = {},
         onNext: @escaping () -> Void = {}
     ) {
         self.navigationStyle = navigationStyle
+        self.shouldRegisterOnNext = shouldRegisterOnNext
         self.onBack = onBack
         self.onNext = onNext
     }
@@ -99,8 +102,17 @@ struct PhoneVerificationView: View {
                     ),
                     isNextEnabled: viewModel.state.isNextEnabled,
                     onTapNext: {
-                        phoneVerificationManager.setPhoneVerified(true)
-                        onNext()
+                        if shouldRegisterOnNext == false {
+                            onNext()
+                            return
+                        }
+
+                        Task {
+                            if await viewModel.registerPhoneVerification() {
+                                phoneVerificationManager.setPhoneVerified(true)
+                                onNext()
+                            }
+                        }
                     }
                 )
             }
@@ -110,12 +122,9 @@ struct PhoneVerificationView: View {
         .toolbar(.hidden, for: .navigationBar)
         .ignoresSafeArea(.keyboard, edges: .bottom)
         .contentShape(Rectangle())
-        .task {
-            let status = await phoneVerificationManager.resolveVerificationStatusIfNeeded()
-
-            if status == .verified {
-                viewModel.applyExistingPhoneVerification()
-            }
+        .onChange(of: viewModel.state.session.isCodeVerified) { isCodeVerified in
+            guard shouldRegisterOnNext == false, isCodeVerified else { return }
+            phoneVerificationManager.setPhoneVerified(true)
         }
         .onTapGesture {
             dismissKeyboard()

--- a/Napzak-iOS/Napzak-iOS/Features/PhoneVerification/Presentation/View/PhoneVerificationView.swift
+++ b/Napzak-iOS/Napzak-iOS/Features/PhoneVerification/Presentation/View/PhoneVerificationView.swift
@@ -65,7 +65,7 @@ struct PhoneVerificationView: View {
                                     set: { viewModel.updateVerificationCode($0) }
                                 ),
                                 timerText: viewModel.state.timerText,
-                                isVerified: viewModel.state.session.isVerified,
+                                isCodeVerified: viewModel.state.session.isCodeVerified,
                                 isCodeInputEnabled: viewModel.state.isVerificationCodeInputEnabled,
                                 buttonState: viewModel.state.verifyButtonState,
                                 onTapVerify: {
@@ -98,7 +98,10 @@ struct PhoneVerificationView: View {
                         set: { _ in viewModel.toggleAgeConfirmation() }
                     ),
                     isNextEnabled: viewModel.state.isNextEnabled,
-                    onTapNext: onNext
+                    onTapNext: {
+                        phoneVerificationManager.setPhoneVerified(true)
+                        onNext()
+                    }
                 )
             }
             .zIndex(1)
@@ -109,11 +112,6 @@ struct PhoneVerificationView: View {
         .contentShape(Rectangle())
         .onTapGesture {
             dismissKeyboard()
-        }
-        .onChange(of: viewModel.state.session.isVerified) { isVerified in
-            if isVerified {
-                phoneVerificationManager.setPhoneVerified(true)
-            }
         }
     }
 

--- a/Napzak-iOS/Napzak-iOS/Features/PhoneVerification/Presentation/View/PhoneVerificationView.swift
+++ b/Napzak-iOS/Napzak-iOS/Features/PhoneVerification/Presentation/View/PhoneVerificationView.swift
@@ -110,6 +110,13 @@ struct PhoneVerificationView: View {
         .toolbar(.hidden, for: .navigationBar)
         .ignoresSafeArea(.keyboard, edges: .bottom)
         .contentShape(Rectangle())
+        .task {
+            let status = await phoneVerificationManager.resolveVerificationStatusIfNeeded()
+
+            if status == .verified {
+                viewModel.applyExistingPhoneVerification()
+            }
+        }
         .onTapGesture {
             dismissKeyboard()
         }

--- a/Napzak-iOS/Napzak-iOS/Features/PhoneVerification/Presentation/ViewModel/PhoneVerificationViewModel.swift
+++ b/Napzak-iOS/Napzak-iOS/Features/PhoneVerification/Presentation/ViewModel/PhoneVerificationViewModel.swift
@@ -32,32 +32,40 @@ final class PhoneVerificationViewModel: ObservableObject {
     }
 
     func updateName(_ name: String) {
-        state.session = state.session.copy(name: name)
+        updateState {
+            $0.session = $0.session.copy(name: name)
+        }
     }
 
     func updatePhoneNumber(_ phoneNumber: String) {
         invalidateVerificationSession()
 
-        state.session = state.session.copy(
-            phoneNumber: phoneNumber.normalizedPhoneNumberInput,
-            verificationCode: "",
-            isCodeSent: false,
-            isVerified: false
-        )
-        state.toastType = nil
+        updateState {
+            $0.session = $0.session.copy(
+                phoneNumber: phoneNumber.normalizedPhoneNumberInput,
+                verificationCode: "",
+                isCodeSent: false,
+                isCodeVerified: false
+            )
+            $0.toastType = nil
+        }
     }
 
     func updateVerificationCode(_ code: String) {
-        state.session = state.session.copy(
-            verificationCode: String(code.digitsOnly.prefix(6)),
-            isVerified: false
-        )
+        updateState {
+            $0.session = $0.session.copy(
+                verificationCode: String(code.digitsOnly.prefix(6)),
+                isCodeVerified: false
+            )
+        }
     }
 
     func toggleAgeConfirmation() {
-        state.session = state.session.copy(
-            isAgeConfirmed: !state.session.isAgeConfirmed
-        )
+        updateState {
+            $0.session = $0.session.copy(
+                isAgeConfirmed: !$0.session.isAgeConfirmed
+            )
+        }
     }
 
     func requestCode() async {
@@ -66,8 +74,14 @@ final class PhoneVerificationViewModel: ObservableObject {
             return
         }
 
-        state.isSendingCode = true
-        defer { state.isSendingCode = false }
+        updateState {
+            $0.isSendingCode = true
+        }
+        defer {
+            updateState {
+                $0.isSendingCode = false
+            }
+        }
 
         let result = await requestCodeUseCase.execute(
             phoneNumber: state.session.phoneNumber
@@ -75,13 +89,15 @@ final class PhoneVerificationViewModel: ObservableObject {
 
         switch result {
         case .success(let sendResult):
-            state.session = state.session.copy(
-                verificationCode: "",
-                isCodeSent: true,
-                isVerified: false
-            )
-            state.remainingRequestCount = sendResult.remainingRequestCount
-            state.remainingSeconds = 180
+            updateState {
+                $0.session = $0.session.copy(
+                    verificationCode: "",
+                    isCodeSent: true,
+                    isCodeVerified: false
+                )
+                $0.remainingRequestCount = sendResult.remainingRequestCount
+                $0.remainingSeconds = 180
+            }
             startTimer()
             showToast(.verificationCodeSent)
 
@@ -105,10 +121,12 @@ final class PhoneVerificationViewModel: ObservableObject {
 
         switch result {
         case .success(let verificationResult):
-            state.session = state.session.copy(
-                isVerified: verificationResult.isPhoneVerified
-            )
-            state.remainingRequestCount = verificationResult.remainingRequestCount
+            updateState {
+                $0.session = $0.session.copy(
+                    isCodeVerified: verificationResult.isPhoneVerified
+                )
+                $0.remainingRequestCount = verificationResult.remainingRequestCount
+            }
 
             if verificationResult.isPhoneVerified {
                 timerTask?.cancel()
@@ -137,12 +155,14 @@ private extension PhoneVerificationViewModel {
 
                 guard Task.isCancelled == false else { return }
 
-                self.state.remainingSeconds -= 1
+                self.updateState {
+                    $0.remainingSeconds -= 1
+                }
             }
 
             guard Task.isCancelled == false,
                   self.state.session.isCodeSent,
-                  self.state.session.isVerified == false,
+                  self.state.session.isCodeVerified == false,
                   self.state.remainingSeconds == 0 else {
                 return
             }
@@ -154,20 +174,26 @@ private extension PhoneVerificationViewModel {
 
     func invalidateVerificationSession() {
         timerTask?.cancel()
-        state.remainingSeconds = 0
-        state.remainingRequestCount = nil
+        updateState {
+            $0.remainingSeconds = 0
+            $0.remainingRequestCount = nil
+        }
     }
 
     func resetVerificationCodeInput() {
-        state.session = state.session.copy(
-            verificationCode: "",
-            isVerified: false
-        )
+        updateState {
+            $0.session = $0.session.copy(
+                verificationCode: "",
+                isCodeVerified: false
+            )
+        }
     }
 
     func expireVerificationSession() {
         timerTask?.cancel()
-        state.remainingSeconds = 0
+        updateState {
+            $0.remainingSeconds = 0
+        }
         resetVerificationCodeInput()
     }
 
@@ -217,7 +243,9 @@ private extension PhoneVerificationViewModel {
     func handleCodeRequestFailure(_ error: PhoneVerificationError) {
         switch error {
         case .requestLimitExceeded:
-            state.remainingRequestCount = 0
+            updateState {
+                $0.remainingRequestCount = 0
+            }
             showToast(.verificationRequestLimitExceeded)
 
         default:
@@ -266,12 +294,22 @@ private extension PhoneVerificationViewModel {
     }
 
     func showToast(_ toastType: VerificationToastType) {
-        state.toastType = toastType
+        updateState {
+            $0.toastType = toastType
+        }
 
         Task { [weak self] in
             try? await Task.sleep(for: .seconds(2))
             guard let self, self.state.toastType == toastType else { return }
-            self.state.toastType = nil
+            self.updateState {
+                $0.toastType = nil
+            }
         }
+    }
+
+    func updateState(_ transform: (inout PhoneVerificationViewState) -> Void) {
+        var newState = state
+        transform(&newState)
+        state = newState
     }
 }

--- a/Napzak-iOS/Napzak-iOS/Features/PhoneVerification/Presentation/ViewModel/PhoneVerificationViewModel.swift
+++ b/Napzak-iOS/Napzak-iOS/Features/PhoneVerification/Presentation/ViewModel/PhoneVerificationViewModel.swift
@@ -141,6 +141,20 @@ final class PhoneVerificationViewModel: ObservableObject {
             handleVerificationFailure(error)
         }
     }
+
+    func applyExistingPhoneVerification() {
+        timerTask?.cancel()
+
+        updateState {
+            $0.session = $0.session.copy(
+                isCodeSent: true,
+                isCodeVerified: true
+            )
+            $0.remainingSeconds = 0
+            $0.toastType = nil
+        }
+    }
+
 }
 
 private extension PhoneVerificationViewModel {

--- a/Napzak-iOS/Napzak-iOS/Features/PhoneVerification/Presentation/ViewModel/PhoneVerificationViewModel.swift
+++ b/Napzak-iOS/Napzak-iOS/Features/PhoneVerification/Presentation/ViewModel/PhoneVerificationViewModel.swift
@@ -262,6 +262,10 @@ private extension PhoneVerificationViewModel {
             }
             showToast(.verificationRequestLimitExceeded)
 
+        case .invalidRequest(let message), .unknown(let message)
+            where message.contains("올바른 휴대폰 번호 형식이 아닙니다."):
+            showToast(.invalidPhoneNumber)
+
         default:
             showToast(mapToastType(from: error))
         }

--- a/Napzak-iOS/Napzak-iOS/Features/PhoneVerification/Presentation/ViewModel/PhoneVerificationViewModel.swift
+++ b/Napzak-iOS/Napzak-iOS/Features/PhoneVerification/Presentation/ViewModel/PhoneVerificationViewModel.swift
@@ -6,13 +6,16 @@
 //
 
 import Foundation
+import os
 
 @MainActor
 final class PhoneVerificationViewModel: ObservableObject {
     @Published private(set) var state = PhoneVerificationViewState()
 
+    private let logger = Logger(subsystem: Bundle.main.bundleIdentifier ?? "Napzak", category: "PhoneVerification")
     private let requestCodeUseCase: RequestPhoneVerificationCodeUseCase
     private let verifyCodeUseCase: VerifyPhoneVerificationCodeUseCase
+    private let storeService: StoreServiceProtocol
     private var timerTask: Task<Void, Never>?
 
     init(
@@ -21,10 +24,12 @@ final class PhoneVerificationViewModel: ObservableObject {
         ),
         verifyCodeUseCase: VerifyPhoneVerificationCodeUseCase = VerifyPhoneVerificationCodeUseCase(
             repository: DefaultPhoneVerificationRepository()
-        )
+        ),
+        storeService: StoreServiceProtocol = NetworkService.shared.storeService
     ) {
         self.requestCodeUseCase = requestCodeUseCase
         self.verifyCodeUseCase = verifyCodeUseCase
+        self.storeService = storeService
     }
 
     deinit {
@@ -52,9 +57,15 @@ final class PhoneVerificationViewModel: ObservableObject {
     }
 
     func updateVerificationCode(_ code: String) {
+        let normalizedCode = String(code.digitsOnly.prefix(6))
+
+        guard state.session.verificationCode != normalizedCode else {
+            return
+        }
+
         updateState {
             $0.session = $0.session.copy(
-                verificationCode: String(code.digitsOnly.prefix(6)),
+                verificationCode: normalizedCode,
                 isCodeVerified: false
             )
         }
@@ -123,16 +134,16 @@ final class PhoneVerificationViewModel: ObservableObject {
         case .success(let verificationResult):
             updateState {
                 $0.session = $0.session.copy(
-                    isCodeVerified: verificationResult.isPhoneVerified
+                    isCodeVerified: verificationResult.isCodeMatched
                 )
                 $0.remainingRequestCount = verificationResult.remainingRequestCount
             }
 
-            if verificationResult.isPhoneVerified {
+            if verificationResult.isCodeMatched {
                 timerTask?.cancel()
             }
 
-            if verificationResult.isPhoneVerified == false {
+            if verificationResult.isCodeMatched == false {
                 resetVerificationCodeInput()
                 showToast(.invalidVerificationCode)
             }
@@ -142,16 +153,18 @@ final class PhoneVerificationViewModel: ObservableObject {
         }
     }
 
-    func applyExistingPhoneVerification() {
-        timerTask?.cancel()
+    func registerPhoneVerification() async -> Bool {
+        let result = await storeService.registerPhoneVerification()
 
-        updateState {
-            $0.session = $0.session.copy(
-                isCodeSent: true,
-                isCodeVerified: true
-            )
-            $0.remainingSeconds = 0
-            $0.toastType = nil
+        switch result {
+        case .success:
+            logger.info("Phone verification registration completed successfully.")
+            return true
+
+        case .failure(let error):
+            logger.error("registerPhoneVerification failed: \(error.localizedDescription)")
+            showToast(.verificationCodeConfirmFailed)
+            return false
         }
     }
 
@@ -262,7 +275,8 @@ private extension PhoneVerificationViewModel {
             }
             showToast(.verificationRequestLimitExceeded)
 
-        case .invalidRequest(let message), .unknown(let message)
+        case .invalidRequest(let message), 
+                .unknown(let message)
             where message.contains("올바른 휴대폰 번호 형식이 아닙니다."):
             showToast(.invalidPhoneNumber)
 

--- a/Napzak-iOS/Napzak-iOS/Global/Core/Auth/AuthManager.swift
+++ b/Napzak-iOS/Napzak-iOS/Global/Core/Auth/AuthManager.swift
@@ -102,7 +102,7 @@ final class AuthManager: ObservableObject {
                     logger.info("Successfully saved tokens to Keychain.")
                 }
                 
-                Task { @MainActor in
+                await MainActor.run {
                     self.isAuthenticated = true
                 }
 
@@ -152,7 +152,7 @@ final class AuthManager: ObservableObject {
         }
         logger.info("logout success")
         
-        Task { @MainActor in
+        await MainActor.run {
             self.isAuthenticated = false
         }
         

--- a/Napzak-iOS/Napzak-iOS/Global/Core/Auth/AuthManager.swift
+++ b/Napzak-iOS/Napzak-iOS/Global/Core/Auth/AuthManager.swift
@@ -102,10 +102,6 @@ final class AuthManager: ObservableObject {
                     logger.info("Successfully saved tokens to Keychain.")
                 }
                 
-                await MainActor.run {
-                    self.isAuthenticated = true
-                }
-
                 return .success(onboardingStep)
                 
             case .failure(let error):
@@ -165,6 +161,11 @@ final class AuthManager: ObservableObject {
     
     func getRefreshToken() -> Result<String, AuthError> {
         return keychain.getRefreshToken()
+    }
+
+    @MainActor
+    func startAuthenticatedSession() {
+        self.isAuthenticated = true
     }
     
     @MainActor

--- a/Napzak-iOS/Napzak-iOS/Global/Core/Onboarding/AuthNavigationRouter.swift
+++ b/Napzak-iOS/Napzak-iOS/Global/Core/Onboarding/AuthNavigationRouter.swift
@@ -15,12 +15,21 @@ final class AuthNavigationRouter: ObservableObject {
     func push(next step: OnboardingStep) {
         path.append(step)
     }
+
+    func replacePath(with steps: [OnboardingStep]) {
+        var newPath = NavigationPath()
+        for step in steps {
+            newPath.append(step)
+        }
+        path = newPath
+    }
     
     func pop() {
         path.removeLast()
     }
     
     func reset() {
+        temporaryUsername = nil
         path = NavigationPath()
     }
 }

--- a/Napzak-iOS/Napzak-iOS/Global/Core/Onboarding/OnboardingStep.swift
+++ b/Napzak-iOS/Napzak-iOS/Global/Core/Onboarding/OnboardingStep.swift
@@ -13,4 +13,19 @@ enum OnboardingStep: String, CaseIterable, Hashable {
     case username
     case genre
     case completed
+
+    var restorationPath: [OnboardingStep] {
+        switch self {
+        case .terms:
+            return [.terms]
+        case .phoneVerification:
+            return [.terms, .phoneVerification]
+        case .username:
+            return [.terms, .phoneVerification, .username]
+        case .genre:
+            return [.terms, .phoneVerification, .username, .genre]
+        case .completed:
+            return [.completed]
+        }
+    }
 }

--- a/Napzak-iOS/Napzak-iOS/Network/Auth/DTO/Response/PhoneVerificationVerifyCodeResponseDTO.swift
+++ b/Napzak-iOS/Napzak-iOS/Network/Auth/DTO/Response/PhoneVerificationVerifyCodeResponseDTO.swift
@@ -10,6 +10,6 @@ import Foundation
 typealias PhoneVerificationVerifyCodeResponseDTO = BaseResponseDTO<PhoneVerificationVerifyCodeDataDTO>
 
 struct PhoneVerificationVerifyCodeDataDTO: Decodable {
-    let isPhoneVerified: Bool
+    let isCodeMatched: Bool
     let remainingRequestCount: Int
 }

--- a/Napzak-iOS/Napzak-iOS/Network/Store/StoreAPI.swift
+++ b/Napzak-iOS/Napzak-iOS/Network/Store/StoreAPI.swift
@@ -11,6 +11,7 @@ enum StoreAPI {
     case getMyPageInfo
     case getStoreDetail(storeId: Int)
     case modifyProfile(request: StoreModifyProfileRequestDTO)
+    case registerPhoneVerification
     case getTerms
     case validateNickname(request: NicknameRequestDTO)
     case registerNickname(request: NicknameRequestDTO)
@@ -35,6 +36,8 @@ extension StoreAPI: BaseTargetType {
             return "stores/\(storeId)"
         case .modifyProfile:
             return "stores/modify/profile"
+        case .registerPhoneVerification:
+            return "stores/phone-verifications"
         case .getTerms:
             return "stores/terms"
         case .validateNickname:
@@ -54,6 +57,8 @@ extension StoreAPI: BaseTargetType {
             return .get
         case .modifyProfile:
             return .put
+        case .registerPhoneVerification:
+            return .patch
         default:
             return .post
         }

--- a/Napzak-iOS/Napzak-iOS/Network/Store/StoreService.swift
+++ b/Napzak-iOS/Napzak-iOS/Network/Store/StoreService.swift
@@ -11,6 +11,7 @@ protocol StoreServiceProtocol {
     func getMyPageInfo() async -> Result<StoreResponseDTO, NetworkError>
     func getStoreDetail(storeId: Int) async -> Result<StoreDetailResponseDTO, NetworkError>
     func modifyProfile(request: StoreModifyProfileRequestDTO) async -> Result<StoreModifyProfileResponseDTO, NetworkError>
+    func registerPhoneVerification() async -> Result<Void, NetworkError>
     func getTerms() async -> Result<TermsResponseDTO, NetworkError>
     func validateNickname(request: NicknameRequestDTO) async -> Result<Void, NetworkError>
     func registerNickname(request: NicknameRequestDTO) async -> Result<Void, NetworkError>
@@ -32,6 +33,10 @@ final class StoreService: BaseService, StoreServiceProtocol {
 
     func modifyProfile(request: StoreModifyProfileRequestDTO) async -> Result<StoreModifyProfileResponseDTO, NetworkError> {
         return await self.requestDecodable(provider, .modifyProfile(request: request))
+    }
+
+    func registerPhoneVerification() async -> Result<Void, NetworkError> {
+        return await requestVoid(provider, .registerPhoneVerification)
     }
     
     func getTerms() async -> Result<TermsResponseDTO, NetworkError> {

--- a/Napzak-iOS/Napzak-iOS/Presentation/Auth/Login/View/LoginView.swift
+++ b/Napzak-iOS/Napzak-iOS/Presentation/Auth/Login/View/LoginView.swift
@@ -6,7 +6,6 @@
 //
 
 import SwiftUI
-import os
 
 import Lottie
 
@@ -118,62 +117,24 @@ extension LoginView {
         hasResumedOnboarding = true
 
         let checkpoint = OnboardingManager.shared.getLastCheckpoint() ?? .terms
-        authRouter.push(next: checkpoint)
+        authRouter.replacePath(with: checkpoint.restorationPath)
     }
 }
 
 private struct OnboardingPhoneVerificationRouteView: View {
     @EnvironmentObject private var authRouter: AuthNavigationRouter
-    @EnvironmentObject private var phoneVerificationManager: PhoneVerificationManager
-
-    @State private var hasResolvedRoute = false
-    @State private var shouldShowVerificationView = false
-
-    private let logger = Logger(
-        subsystem: Bundle.main.bundleIdentifier ?? "Napzak",
-        category: "OnboardingPhoneVerificationRoute"
-    )
 
     var body: some View {
-        Group {
-            if shouldShowVerificationView {
-                PhoneVerificationView(
-                    navigationStyle: .onboarding(step: 2),
-                    onBack: {
-                        authRouter.pop()
-                    },
-                    onNext: {
-                        OnboardingManager.shared.saveCheckpoint(.username)
-                        authRouter.push(next: .username)
-                    }
-                )
-            } else {
-                Color.clear
-                    .ignoresSafeArea()
+        PhoneVerificationView(
+            navigationStyle: .onboarding(step: 2),
+            onBack: {
+                authRouter.pop()
+            },
+            onNext: {
+                OnboardingManager.shared.saveCheckpoint(.username)
+                authRouter.push(next: .username)
             }
-        }
-        .task {
-            await resolveRouteIfNeeded()
-        }
-    }
-}
-
-extension OnboardingPhoneVerificationRouteView {
-    @MainActor
-    private func resolveRouteIfNeeded() async {
-        guard hasResolvedRoute == false else { return }
-        hasResolvedRoute = true
-
-        let status = await phoneVerificationManager.refreshStatus()
-        logger.info("Onboarding phone verification route resolved - status: \(String(describing: status))")
-        OnboardingManager.shared.saveCheckpoint(.phoneVerification)
-        shouldShowVerificationView = true
-
-        if status == .verified {
-            logger.info("Phone already verified - presenting onboarding phone verification view in completed state")
-        } else {
-            logger.info("Phone not verified - presenting onboarding phone verification view")
-        }
+        )
     }
 }
 

--- a/Napzak-iOS/Napzak-iOS/Presentation/Auth/Login/View/LoginView.swift
+++ b/Napzak-iOS/Napzak-iOS/Presentation/Auth/Login/View/LoginView.swift
@@ -43,7 +43,10 @@ struct LoginView: View {
                         VStack(spacing: 15) {
                             Button {
                                 Task {
-                                    await viewModel.handleKakaoLogin(router: authRouter)
+                                    await viewModel.handleKakaoLogin(
+                                        router: authRouter,
+                                        phoneVerificationManager: phoneVerificationManager
+                                    )
                                 }
                             } label: {
                                 Image(.buttonLoginKakao)
@@ -52,7 +55,10 @@ struct LoginView: View {
                             
                             Button {
                                 Task {
-                                    await viewModel.handleAppleAuthCode(router: authRouter)
+                                    await viewModel.handleAppleAuthCode(
+                                        router: authRouter,
+                                        phoneVerificationManager: phoneVerificationManager
+                                    )
                                 }
                             } label: {
                                 Image(.buttonLoginApple)

--- a/Napzak-iOS/Napzak-iOS/Presentation/Auth/Login/View/LoginView.swift
+++ b/Napzak-iOS/Napzak-iOS/Presentation/Auth/Login/View/LoginView.swift
@@ -164,20 +164,16 @@ extension OnboardingPhoneVerificationRouteView {
         guard hasResolvedRoute == false else { return }
         hasResolvedRoute = true
 
-        let status = await phoneVerificationManager.resolveVerificationStatusIfNeeded()
+        let status = await phoneVerificationManager.refreshStatus()
         logger.info("Onboarding phone verification route resolved - status: \(String(describing: status))")
-
-        if status == .verified {
-            logger.info("Phone already verified - skipping onboarding phone verification step")
-            OnboardingManager.shared.saveCheckpoint(.username)
-            authRouter.pop()
-            authRouter.push(next: .username)
-            return
-        }
-
-        logger.info("Phone not verified - presenting onboarding phone verification view")
         OnboardingManager.shared.saveCheckpoint(.phoneVerification)
         shouldShowVerificationView = true
+
+        if status == .verified {
+            logger.info("Phone already verified - presenting onboarding phone verification view in completed state")
+        } else {
+            logger.info("Phone not verified - presenting onboarding phone verification view")
+        }
     }
 }
 

--- a/Napzak-iOS/Napzak-iOS/Presentation/Auth/Login/ViewModel/LoginViewModel.swift
+++ b/Napzak-iOS/Napzak-iOS/Presentation/Auth/Login/ViewModel/LoginViewModel.swift
@@ -34,7 +34,7 @@ final class LoginViewModel: ObservableObject {
             logger.info("로그인 성공")
             UserDefaults.standard.set("kakao", forKey: "loginPlatform")
 
-            router.push(next: onboardingStep)
+            router.replacePath(with: onboardingStep.restorationPath)
             mixpanelManager.trackEvent(event: "Signed Up")
         case .failure(let error):
             // TODO: - 서버 오류 시 팝업 필요
@@ -63,7 +63,7 @@ final class LoginViewModel: ObservableObject {
             logger.info("로그인 성공")
             UserDefaults.standard.set("apple", forKey: "loginPlatform")
 
-            router.push(next: onboardingStep)
+            router.replacePath(with: onboardingStep.restorationPath)
             if onboardingStep == .completed {
                 mixpanelManager.trackEvent(event: "Signed Up")
             }

--- a/Napzak-iOS/Napzak-iOS/Presentation/Auth/Login/ViewModel/LoginViewModel.swift
+++ b/Napzak-iOS/Napzak-iOS/Presentation/Auth/Login/ViewModel/LoginViewModel.swift
@@ -17,10 +17,12 @@ final class LoginViewModel: ObservableObject {
     @Published var showAlert = false
     
     private let authManager = AuthManager.shared
-    private let onboardingManager = OnboardingManager.shared
     private let mixpanelManager = MixpanelManager.shared
 
-    func handleKakaoLogin(router: AuthNavigationRouter) async {
+    func handleKakaoLogin(
+        router: AuthNavigationRouter,
+        phoneVerificationManager: PhoneVerificationManager
+    ) async {
         guard !isLoading else { return }
         isLoading = true
         defer { isLoading = false }
@@ -34,7 +36,16 @@ final class LoginViewModel: ObservableObject {
             logger.info("로그인 성공")
             UserDefaults.standard.set("kakao", forKey: "loginPlatform")
 
-            router.replacePath(with: onboardingStep.restorationPath)
+            phoneVerificationManager.reset()
+            await authManager.fetchMyStoreId()
+            await authManager.fetchChatRoomIdsToWebSocket()
+            await phoneVerificationManager.refreshStatus()
+
+            if onboardingStep != .completed {
+                router.replacePath(with: onboardingStep.restorationPath)
+            }
+
+            authManager.startAuthenticatedSession()
             mixpanelManager.trackEvent(event: "Signed Up")
         case .failure(let error):
             // TODO: - 서버 오류 시 팝업 필요
@@ -49,7 +60,10 @@ final class LoginViewModel: ObservableObject {
         }
     }
     
-    func handleAppleAuthCode(router: AuthNavigationRouter) async {
+    func handleAppleAuthCode(
+        router: AuthNavigationRouter,
+        phoneVerificationManager: PhoneVerificationManager
+    ) async {
         guard !isLoading else { return }
         isLoading = true
         defer { isLoading = false }
@@ -63,7 +77,16 @@ final class LoginViewModel: ObservableObject {
             logger.info("로그인 성공")
             UserDefaults.standard.set("apple", forKey: "loginPlatform")
 
-            router.replacePath(with: onboardingStep.restorationPath)
+            phoneVerificationManager.reset()
+            await authManager.fetchMyStoreId()
+            await authManager.fetchChatRoomIdsToWebSocket()
+            await phoneVerificationManager.refreshStatus()
+
+            if onboardingStep != .completed {
+                router.replacePath(with: onboardingStep.restorationPath)
+            }
+
+            authManager.startAuthenticatedSession()
             if onboardingStep == .completed {
                 mixpanelManager.trackEvent(event: "Signed Up")
             }

--- a/Napzak-iOS/Napzak-iOS/Presentation/Onboarding/View/OnboardingTermsView.swift
+++ b/Napzak-iOS/Napzak-iOS/Presentation/Onboarding/View/OnboardingTermsView.swift
@@ -9,6 +9,7 @@ import SwiftUI
 
 struct OnboardingTermsView: View {
     @EnvironmentObject private var authRouter: AuthNavigationRouter
+    @EnvironmentObject private var phoneVerificationManager: PhoneVerificationManager
     @StateObject private var viewModel = OnboardingTermsViewModel()
     @State private var isAllAgreed: Bool = false
     @State private var isTermsAgreed: Bool = false
@@ -17,7 +18,9 @@ struct OnboardingTermsView: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             OnboardingNavigationBar(step: 1) {
-                authRouter.pop()
+                phoneVerificationManager.reset()
+                AuthManager.shared.forceLogout()
+                authRouter.reset()
             }
             .frame(height: 48)
             

--- a/Napzak-iOS/Napzak-iOS/Presentation/Onboarding/ViewModel/GenreSelectionViewModel.swift
+++ b/Napzak-iOS/Napzak-iOS/Presentation/Onboarding/ViewModel/GenreSelectionViewModel.swift
@@ -76,14 +76,22 @@ final class GenreSelectionViewModel: ObservableObject {
             let genreIds = selectedGenres.map { $0.id }
             let genreRequest = PreferGenreRequestDTO(genreIds: genreIds)
             let genreResult = await genreService.registerPreferGenre(request: genreRequest)
-            
-            isLoading = false
-            
+
             switch genreResult {
             case .success(_):
-                logger.info("User and genres registered successfully.")
-                return true
+                let phoneResult = await storeService.registerPhoneVerification()
+                isLoading = false
+
+                switch phoneResult {
+                case .success:
+                    logger.info("User, genres, and phone number registered successfully.")
+                    return true
+                case .failure(let error):
+                    logger.error("registerPhoneVerification failed: \(error.localizedDescription)")
+                    return false
+                }
             case .failure(let error):
+                isLoading = false
                 logger.error("registerPreferGenre failed: \(error.localizedDescription)")
                 return false
             }
@@ -98,13 +106,22 @@ final class GenreSelectionViewModel: ObservableObject {
         isLoading = true
         let nicknameRequest = NicknameRequestDTO(nickname: username)
         let result = await storeService.registerNickname(request: nicknameRequest)
-        isLoading = false
         
         switch result {
         case .success:
-            logger.info("Username registered successfully, skipping genres.")
-            return true
+            let phoneResult = await storeService.registerPhoneVerification()
+            isLoading = false
+
+            switch phoneResult {
+            case .success:
+                logger.info("Username and phone number registered successfully, skipping genres.")
+                return true
+            case .failure(let error):
+                logger.error("registerPhoneVerification failed for skip action: \(error.localizedDescription)")
+                return false
+            }
         case .failure(let error):
+            isLoading = false
             logger.error("registerNickname failed for skip action: \(error.localizedDescription)")
             return false
         }

--- a/Napzak-iOS/Napzak-iOS/Presentation/TabBar/View/NZTabBarView.swift
+++ b/Napzak-iOS/Napzak-iOS/Presentation/TabBar/View/NZTabBarView.swift
@@ -143,6 +143,7 @@ struct NZTabBarView: View {
                 case .phoneVerificationView:
                     PhoneVerificationView(
                         navigationStyle: .basic,
+                        shouldRegisterOnNext: true,
                         onBack: {
                             if let entryPoint = phoneVerificationManager.currentEntryPoint {
                                 phoneVerificationManager.presentModal(for: entryPoint)

--- a/Napzak-iOS/Napzak-iOSTests/OnboardingManagerTests.swift
+++ b/Napzak-iOS/Napzak-iOSTests/OnboardingManagerTests.swift
@@ -86,5 +86,13 @@ struct OnboardingManagerTests {
         // then
         #expect(checkpoint == nil, "저장된 온보딩 정보가 없으면 nil을 반환해야 합니다.")
     }
-}
 
+    @Test("시나리오 5: 마지막 체크포인트에 맞춰 이전 온보딩 화면 스택이 복원되어야 한다")
+    func restorationPath_matchesExpectedOnboardingStack() throws {
+        #expect(OnboardingStep.terms.restorationPath == [.terms])
+        #expect(OnboardingStep.phoneVerification.restorationPath == [.terms, .phoneVerification])
+        #expect(OnboardingStep.username.restorationPath == [.terms, .phoneVerification, .username])
+        #expect(OnboardingStep.genre.restorationPath == [.terms, .phoneVerification, .username, .genre])
+        #expect(OnboardingStep.completed.restorationPath == [.completed])
+    }
+}


### PR DESCRIPTION
## 🌴 작업한 브랜치
- #203


## ✅ 작업한 내용
<!-- 작업한 내용 적어주세요! -->
### 010 외 다른 번호 입력 시 에러 메시지

000-0000-0000 까지만 형식 검증을하고 그외 올바르지 않은 번호는 서버응답에 따라 토스트 나타나도록 개선


### 기존 가입자에게 번호 인증 모달 노출

- 문제: 이미 번호 인증한 사용자도 재로그인 시 번호 인증 모달이 다시 뜰 수 있었음
- 원인: 현재 계정 기준 상태 재확인이 부족했고, 일부 플로우에서 이전 상태값 영향을 받을 수 있었음
- 해결: 재진입/재로그인 시 현재 로그인한 계정의 번호 인증 상태를 기준으로 다시 판단하도록 수정
- 기대 결과: 번호 인증 완료 사용자는 모달이 뜨지 않고, 미완료 사용자만 모달이 노출됨


### 가입되지 않은 번호인데 가입 불가

- 문제: 번호 인증만 끝난 사용자가 온보딩을 완료하지 않았는데도 유저 네임 설정 단계로 스킵됨
- 원인: 번호 인증 완료와 온보딩 phoneVerification 단계 완료를 동일하게 취급
- 기획상 맞는 기준: 만 14세 이상 체크와 다음으로 클릭까지 있어야 해당 단계 완료
- 해결 방향: 번호 인증 상태와 온보딩 단계 완료 상태를 분리해 처리


<!--
```
넣고싶은 코드가 있다면 적어주세요
```
-->


## ❗️PR Point
<!-- 부족했던 점 혹은 개선하고 싶은 방향이 있다면 얘기해주세요 -->

<!--
```
넣고싶은 코드가 있다면 적어주세요
```
-->


## 📸 스크린샷
<!-- 스크린 샷을 첨부해주세요 -->
|기능|스크린샷|
|:--:|:--:|
|GIF|<img src = "" width ="250">|


## 📟 관련 이슈
- Resolved: #203


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **신규 기능**
  * 매장 연동을 위한 전화인증 등록 API 연동 및 관련 ViewModel 등록 동작 추가
  * 온보딩 경로 전체 교체 기능(replacePath) 및 단계 복원 경로(restorationPath) 도입

* **버그 수정**
  * 인증 코드 검증/요청 실패 처리 개선(요청 한도 반영, 잘못된 번호 메시지 매핑)
  * 온보딩 뒤로가기 시 인증 상태 초기화 및 강제 로그아웃 적용

* **개선 사항**
  * 전화인증 상태(isCodeVerified)와 타이머/UI 로직 정리 및 상태 업데이트 통합
  * 로그인/세션 시작 흐름과 네비게이션 동기화 개선

* **테스트**
  * 온보딩 복원 경로 검증 테스트 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->