### PR TITLE
[Fix] #205 - 온보딩 완료 시 번호인증 로컬 상태 동기화

### DIFF
--- a/Napzak-iOS/Napzak-iOS.xcodeproj/project.pbxproj
+++ b/Napzak-iOS/Napzak-iOS.xcodeproj/project.pbxproj
@@ -2640,7 +2640,7 @@
 				CODE_SIGN_ENTITLEMENTS = "Napzak-iOS/Napzak-iOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 2;
 				DEVELOPMENT_ASSET_PATHS = "\"Napzak-iOS/Application/Preview Content\"";
 				DEVELOPMENT_TEAM = 2G7ZY93ALK;
 				ENABLE_PREVIEWS = YES;
@@ -2681,7 +2681,7 @@
 				CODE_SIGN_ENTITLEMENTS = "Napzak-iOS/Napzak-iOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 2;
 				DEVELOPMENT_ASSET_PATHS = "\"Napzak-iOS/Application/Preview Content\"";
 				DEVELOPMENT_TEAM = 2G7ZY93ALK;
 				ENABLE_PREVIEWS = YES;

--- a/Napzak-iOS/Napzak-iOS/Presentation/Onboarding/View/GenreSelectionView.swift
+++ b/Napzak-iOS/Napzak-iOS/Presentation/Onboarding/View/GenreSelectionView.swift
@@ -9,6 +9,7 @@ import SwiftUI
 
 struct GenreSelectionView: View {
     @EnvironmentObject private var authRouter: AuthNavigationRouter
+    @EnvironmentObject private var phoneVerificationManager: PhoneVerificationManager
     @StateObject private var viewModel = GenreSelectionViewModel()
     @FocusState private var isSearchFocused: Bool
     @State private var isSearchCompleted: Bool = false
@@ -161,6 +162,7 @@ extension GenreSelectionView {
                     let username = authRouter.temporaryUsername ?? ""
                     
                     if await viewModel.registerUser(username: username) {
+                        phoneVerificationManager.setPhoneVerified(true)
                         authRouter.push(next: .completed)
                     }
                     
@@ -188,6 +190,7 @@ extension GenreSelectionView {
                     let username = authRouter.temporaryUsername ?? ""
                     
                     if await viewModel.registerOnlyUsername(username: username) {
+                        phoneVerificationManager.setPhoneVerified(true)
                         authRouter.push(next: .completed)
                     }
                 }


### PR DESCRIPTION
## 🌴 작업한 브랜치
- #205


## ✅ 작업한 내용
<!-- 작업한 내용 적어주세요! -->
온보딩 중 번호인증 후 닉네임/장르 단계에서 이탈했다가 복귀해 온보딩을 완료하면 서버에는 번호인증 완료가 반영되지만 로컬 번호
인증 캐시가 갱신되지 않아 메인 진입 후 번호인증 팝업이 다시 노출되는 이슈를 해결.

<!--
```
넣고싶은 코드가 있다면 적어주세요
```
-->


## ❗️PR Point
<!-- 부족했던 점 혹은 개선하고 싶은 방향이 있다면 얘기해주세요 -->

<!--
```
넣고싶은 코드가 있다면 적어주세요
```
-->


## 📸 스크린샷
<!-- 스크린 샷을 첨부해주세요 -->
|기능|스크린샷|
|:--:|:--:|
|GIF|<img src = "" width ="250">|


## 📟 관련 이슈
- Resolved: #205 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **기능 개선**
  * 회원가입 프로세스 완료 후 휴대폰 인증 상태가 정상적으로 기록됩니다.
  * 납작마켓 시작하기와 건너뛰기 옵션 선택 시 휴대폰 인증 상태가 일관되게 관리됩니다.

* **기타**
  * 앱 빌드 버전이 업데이트되었습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/napzakmarket/Napzak-iOS/pull/206?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->