### PR TITLE
[Fix] #207 - 재설치 시 Keychain 토큰 초기화 로직 추가

### DIFF
--- a/Napzak-iOS/Napzak-iOS/Global/Core/Auth/AuthManager.swift
+++ b/Napzak-iOS/Napzak-iOS/Global/Core/Auth/AuthManager.swift
@@ -17,6 +17,7 @@ final class AuthManager: ObservableObject {
     private let keychain = KeychainManager.shared
     private let onboardingManager = OnboardingManager.shared
     private let authService = NetworkService.shared.authService
+    private let appInstallStateManager = AppInstallStateManager()
     
     @Published var isAuthenticated: Bool
     
@@ -30,6 +31,15 @@ final class AuthManager: ObservableObject {
 //        OnboardingManager.shared.clearProgress()
 //        logger.info("[DEBUG] Keychain cleared for login testing")
 //        #endif
+        switch appInstallStateManager.clearKeychainIfNeededOnFirstLaunch() {
+        case .success(true):
+            logger.info("First launch detected. Cleared persisted Keychain tokens.")
+        case .success(false):
+            break
+        case .failure(let error):
+            logger.error("Failed to clear Keychain tokens on first launch: \(error.localizedDescription)")
+        }
+
         self.isAuthenticated = (try? keychain.getAccessToken().get()) != nil
         
         if let checkpoint = onboardingManager.getLastCheckpoint() {
@@ -183,6 +193,36 @@ final class AuthManager: ObservableObject {
         keychain.clearTokens()
         onboardingManager.clearProgress()
         self.isAuthenticated = false
+    }
+}
+
+final class AppInstallStateManager {
+    private let defaults: UserDefaults
+    private let installMarkerKey = "app_HasLaunchedBefore"
+    private let keychainClearAction: () -> Result<Void, AuthError>
+
+    init(
+        defaults: UserDefaults = .standard,
+        keychainClearAction: @escaping () -> Result<Void, AuthError> = {
+            KeychainManager.shared.clearTokens()
+        }
+    ) {
+        self.defaults = defaults
+        self.keychainClearAction = keychainClearAction
+    }
+
+    func clearKeychainIfNeededOnFirstLaunch() -> Result<Bool, AuthError> {
+        guard defaults.object(forKey: installMarkerKey) == nil else {
+            return .success(false)
+        }
+
+        switch keychainClearAction() {
+        case .success:
+            defaults.set(true, forKey: installMarkerKey)
+            return .success(true)
+        case .failure(let error):
+            return .failure(error)
+        }
     }
 }
 

--- a/Napzak-iOS/Napzak-iOSTests/OnboardingManagerTests.swift
+++ b/Napzak-iOS/Napzak-iOSTests/OnboardingManagerTests.swift
@@ -12,6 +12,12 @@ import Foundation
 @MainActor
 struct OnboardingManagerTests {
 
+    private func makeTestDefaults(suiteName: String = UUID().uuidString) -> UserDefaults {
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defaults.removePersistentDomain(forName: suiteName)
+        return defaults
+    }
+
     private func cleanupUserDefaults() {
         let defaults = UserDefaults.standard
         defaults.removeObject(forKey: "onboarding_Checkpoint")
@@ -94,5 +100,87 @@ struct OnboardingManagerTests {
         #expect(OnboardingStep.username.restorationPath == [.terms, .phoneVerification, .username])
         #expect(OnboardingStep.genre.restorationPath == [.terms, .phoneVerification, .username, .genre])
         #expect(OnboardingStep.completed.restorationPath == [.completed])
+    }
+
+    @Test("시나리오 6: 앱 첫 실행으로 판단되면 Keychain 정리 로직이 한 번 실행되어야 한다")
+    func clearKeychainIfNeededOnFirstLaunch_whenMarkerMissing() throws {
+        let defaults = makeTestDefaults()
+        var clearCallCount = 0
+        let manager = AppInstallStateManager(
+            defaults: defaults,
+            keychainClearAction: {
+                clearCallCount += 1
+                return .success(())
+            }
+        )
+
+        let result = manager.clearKeychainIfNeededOnFirstLaunch()
+
+        switch result {
+        case .success(let didClear):
+            #expect(didClear)
+        case .failure(let error):
+            Issue.record("Expected success but received \(error)")
+        }
+
+        #expect(clearCallCount == 1, "첫 실행 시 Keychain 정리 로직이 정확히 한 번 호출되어야 합니다.")
+        #expect(
+            defaults.bool(forKey: "app_HasLaunchedBefore"),
+            "첫 실행 처리 후에는 다음 실행을 구분할 수 있도록 마커가 저장되어야 합니다."
+        )
+    }
+
+    @Test("시나리오 7: 이미 실행 마커가 있으면 Keychain 정리 로직이 다시 호출되지 않아야 한다")
+    func clearKeychainIfNeededOnFirstLaunch_whenMarkerExists() throws {
+        let defaults = makeTestDefaults()
+        defaults.set(true, forKey: "app_HasLaunchedBefore")
+        var clearCallCount = 0
+        let manager = AppInstallStateManager(
+            defaults: defaults,
+            keychainClearAction: {
+                clearCallCount += 1
+                return .success(())
+            }
+        )
+
+        let result = manager.clearKeychainIfNeededOnFirstLaunch()
+
+        switch result {
+        case .success(let didClear):
+            #expect(didClear == false)
+        case .failure(let error):
+            Issue.record("Expected success but received \(error)")
+        }
+
+        #expect(clearCallCount == 0, "재실행에서는 Keychain 정리 로직이 호출되지 않아야 합니다.")
+    }
+
+    @Test("시나리오 8: Keychain 정리에 실패하면 실행 마커를 저장하지 않아야 한다")
+    func clearKeychainIfNeededOnFirstLaunch_whenCleanupFails() throws {
+        let defaults = makeTestDefaults()
+        let manager = AppInstallStateManager(
+            defaults: defaults,
+            keychainClearAction: {
+                .failure(.keychainError)
+            }
+        )
+
+        let result = manager.clearKeychainIfNeededOnFirstLaunch()
+
+        switch result {
+        case .success:
+            Issue.record("Expected failure but received success")
+        case .failure(let error):
+            if case .keychainError = error {
+                break
+            } else {
+                Issue.record("Expected keychainError but received \(error)")
+            }
+        }
+
+        #expect(
+            defaults.object(forKey: "app_HasLaunchedBefore") == nil,
+            "정리에 실패한 경우에는 다음 실행에서 재시도할 수 있도록 마커가 저장되면 안 됩니다."
+        )
     }
 }


### PR DESCRIPTION
## 🌴 작업한 브랜치
- #207 


## ✅ 작업한 내용

  앱 재설치 시 Keychain에 남아 있는 토큰 때문에 인증 상태와 온보딩 상태가 어긋나는 문제를 수정했습니다.

  기존에는 앱을 삭제 후 재설치하면:
  - UserDefaults는 초기화되어 온보딩 완료 정보가 사라지고
  - Keychain의 access/refresh token은 유지되어 로그인된 사용자로 판단되는 문제가 있었습니다.

  이 때문에 사이드이펙트가 발생했습니다.

  이번 작업에서는 앱 첫 실행 여부를 UserDefaults 마커로 판단하고,
  재설치 후 첫 실행으로 확인되면 Keychain 토큰을 먼저 초기화한 뒤 인증 상태를 계산하도록 변경했습니다.

  즉:
  - 같은 설치에서 앱 재실행: 기존 토큰 유지
  - 앱 삭제 후 재설치: 첫 실행에서 토큰 삭제 후 로그인 화면 진입

  ### - 대표 코드

```swift
 private init() {
      switch appInstallStateManager.clearKeychainIfNeededOnFirstLaunch() {
      case .success(true):
          logger.info("First launch detected. Cleared persisted Keychain tokens.")
      case .success(false):
          break
      case .failure(let error):
          logger.error("Failed to clear Keychain tokens on first launch:
  \(error.localizedDescription)")
      }

      self.isAuthenticated = (try? keychain.getAccessToken().get()) != nil
  }
```

  ### - 동작 흐름

  1. 앱 실행 시 먼저 UserDefaults의 설치 마커를 확인합니다.
  2. 설치 마커가 없으면 재설치 후 첫 실행으로 판단합니다.
  3. 이 경우 Keychain에 남아 있던 access/refresh token을 삭제합니다.
  4. 이후에 Keychain 기준으로 로그인 상태를 다시 계산합니다.
  5. 따라서 재설치 직후에는 자동 로그인되지 않고 로그인 화면으로 정상 진입합니다.

  ### - 테스트 코드 추가




## ❗️PR Point
<!-- 부족했던 점 혹은 개선하고 싶은 방향이 있다면 얘기해주세요 -->

<!--
```
넣고싶은 코드가 있다면 적어주세요
```
-->


## 📸 스크린샷
<!-- 스크린 샷을 첨부해주세요 -->
|기능|스크린샷|
|:--:|:--:|
|GIF|<img src = "" width ="250">|


## 📟 관련 이슈
- Resolved: #207
