### PR TITLE
[Fix] #217 - Refresh Token 만료 시 안정화 작업

### DIFF
--- a/Napzak-iOS/Napzak-iOS/Application/RootView.swift
+++ b/Napzak-iOS/Napzak-iOS/Application/RootView.swift
@@ -14,11 +14,12 @@ struct RootView: View {
     
     @ObservedObject private var authManager = AuthManager.shared
     @State private var isShowingSplash = true
+    @State private var hasStartedAuthenticatedSession = false
     
     let appID = "6740986515"
     var body: some View {
         Group {
-            if isShowingSplash {
+            if isShowingSplash || authManager.isRestoringSession {
                 SplashView()
                     .transition(.opacity)
             } else if authManager.isAuthenticated && !authManager.needsOnboarding {
@@ -51,7 +52,10 @@ struct RootView: View {
             }
         }
         .onChange(of: authManager.isAuthenticated) { isAuthenticated in
-            if isAuthenticated == false {
+            if isAuthenticated {
+                handleAuthenticatedSessionStart()
+            } else {
+                hasStartedAuthenticatedSession = false
                 phoneVerificationManager.reset()
             }
         }
@@ -67,11 +71,15 @@ struct RootView: View {
 
 extension RootView {
     private func handleAuthenticatedSessionStart() {
+        guard hasStartedAuthenticatedSession == false else { return }
+        hasStartedAuthenticatedSession = true
         phoneVerificationManager.reset()
 
         Task {
             await authManager.fetchMyStoreId()
+            guard authManager.isAuthenticated else { return }
             await authManager.fetchChatRoomIdsToWebSocket()
+            guard authManager.isAuthenticated else { return }
             await phoneVerificationManager.refreshStatus()
         }
     }

--- a/Napzak-iOS/Napzak-iOS/Global/Core/Auth/AuthManager.swift
+++ b/Napzak-iOS/Napzak-iOS/Global/Core/Auth/AuthManager.swift
@@ -20,6 +20,7 @@ final class AuthManager: ObservableObject {
     private let appInstallStateManager = AppInstallStateManager()
     
     @Published var isAuthenticated: Bool
+    @Published var isRestoringSession: Bool
     
     var needsOnboarding: Bool {
         onboardingManager.getLastCheckpoint() != .completed
@@ -41,7 +42,8 @@ final class AuthManager: ObservableObject {
         }
 
         let hasStoredTokens = Self.hasStoredTokens(in: keychain)
-        self.isAuthenticated = hasStoredTokens
+        self.isAuthenticated = false
+        self.isRestoringSession = hasStoredTokens
         
         if let checkpoint = onboardingManager.getLastCheckpoint() {
             logger.info("Current onboarding checkpoint: \(checkpoint.rawValue)")
@@ -50,14 +52,14 @@ final class AuthManager: ObservableObject {
         }
         
         if hasStoredTokens {
-            logger.info("Existing accessToken and refreshToken found in Keychain")
+            logger.info("Existing token pair found. Restoring session")
             Task {
-                await fetchMyStoreId()
-                await fetchChatRoomIdsToWebSocket()
+                await restoreStoredSession()
             }
         } else {
             logger.info("No complete token pair found in Keychain at startup")
             keychain.clearTokens()
+            self.isRestoringSession = false
         }
     }
 
@@ -163,6 +165,7 @@ final class AuthManager: ObservableObject {
         logger.info("logout success")
         
         await MainActor.run {
+            self.isRestoringSession = false
             self.isAuthenticated = false
         }
         
@@ -179,6 +182,7 @@ final class AuthManager: ObservableObject {
 
     @MainActor
     func startAuthenticatedSession() {
+        self.isRestoringSession = false
         self.isAuthenticated = true
     }
     
@@ -196,7 +200,27 @@ final class AuthManager: ObservableObject {
     func forceLogout() {
         keychain.clearTokens()
         onboardingManager.clearProgress()
+        self.isRestoringSession = false
         self.isAuthenticated = false
+    }
+
+    private func restoreStoredSession() async {
+        let refreshResult = await TokenRefresher.shared.refresh()
+
+        await MainActor.run {
+            self.isRestoringSession = false
+
+            switch refreshResult {
+            case .success:
+                self.logger.info("Session restored")
+                self.isAuthenticated = true
+
+            case .failure(let error):
+                self.logger.error("Session restore failed: \(error.localizedDescription)")
+                self.keychain.clearTokens()
+                self.isAuthenticated = false
+            }
+        }
     }
 }
 

--- a/Napzak-iOS/Napzak-iOS/Network/Base/BaseTargetType.swift
+++ b/Napzak-iOS/Napzak-iOS/Network/Base/BaseTargetType.swift
@@ -53,4 +53,3 @@ extension BaseTargetType {
     }
     
 }
-


### PR DESCRIPTION
## 🌴 작업한 브랜치
- #217 


## ✅ 작업한 내용
<!-- 작업한 내용 적어주세요! -->

 ## 변경 사항
  - 앱 시작 시 저장된 토큰이 있어도 바로 인증 상태로 진입하지 않고, refresh API로 세션 복원을 먼저 검증하도록 변경했습니다.
  - 세션 복원 중에는 Splash를 유지하고, 복원 성공 후에만 Main 초기 API를 호출하도록 조정했습니다.
  - 초기 인증 API 실행 중 로그아웃이 발생하면 이후 API 호출을 중단하도록 방어 로직을 추가했습니다.

  ## 기존 문제 원인
  기존에는 Keychain에 access/refresh token이 존재하면 즉시 `isAuthenticated = true`로 처리해 Main 화면에 진입했습니다. refresh
  token이 만료된 경우에도 초기 API들이 먼저 실행되면서 401, refresh 실패, 로그아웃, 후속 API 재호출이 섞여 무한 로딩처럼 보일 수
  있었습니다.

  ## 해결 방식
  토큰 존재 여부만으로 자동 로그인하지 않고, 앱 시작 시 refresh token으로 세션 복원을 1회 검증합니다. 복원 성공 시에만 Main으로 진
  입하고, 실패하면 토큰을 삭제한 뒤 Login 플로우로 전환합니다.

<!--
```
넣고싶은 코드가 있다면 적어주세요
```
-->


## ❗️PR Point
<!-- 부족했던 점 혹은 개선하고 싶은 방향이 있다면 얘기해주세요 -->

<!--
```
넣고싶은 코드가 있다면 적어주세요
```
-->


## 📸 스크린샷
<!-- 스크린 샷을 첨부해주세요 -->
|기능|스크린샷|
|:--:|:--:|
|GIF|<img src = "" width ="250">|


## 📟 관련 이슈
- Resolved: #217 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
  - 앱 실행 시 저장된 로그인 세션을 자동으로 복구합니다.
  - 세션 복구가 완료될 때까지 스플래시 화면이 안정적으로 표시됩니다.
  - 로그아웃 또는 인증 만료 시 후속 작업이 실행되지 않도록 개선했습니다.
  - 로그인 세션 시작 과정에서 중복 처리를 방지하고 전화번호 인증 상태를 초기화합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->